### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/tests/core/test_ssrf_protection.py
+++ b/tests/core/test_ssrf_protection.py
@@ -14,6 +14,7 @@ Source: Task 11 from review/07_PLAN_UPDATES.md
 import pytest
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 # Add src to path for imports
 ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -401,8 +402,9 @@ class TestURLValidatorUtilities:
         """Test that URL sanitization preserves hostname."""
         url = "https://example.com/path"
         sanitized = URLValidator.sanitize_url_for_logging(url)
-        
-        assert "example.com" in sanitized
+        parsed = urlparse(sanitized)
+
+        assert parsed.hostname == "example.com"
 
 
 # =============================================================================


### PR DESCRIPTION
Potential fix for [https://github.com/falloutxAY/rdf-dtdl-fabric-ontology-converter/security/code-scanning/2](https://github.com/falloutxAY/rdf-dtdl-fabric-ontology-converter/security/code-scanning/2)

In general, to avoid incomplete URL substring checks, the code should parse the URL and inspect its structured components (e.g., using `urllib.parse.urlparse` to get `hostname`) instead of checking for a raw substring in the full URL string.

For this specific test, the intention is to ensure that `sanitize_url_for_logging` preserves the hostname. Rather than asserting `"example.com" in sanitized`, we should parse the sanitized URL and assert that its hostname is exactly `"example.com"`. This continues to verify that the hostname is preserved, but uses proper URL parsing instead of a substring search.

Concretely:
- In `tests/core/test_ssrf_protection.py`, add an import for `urlparse` from `urllib.parse`.
- Update `test_sanitize_url_preserves_hostname` to:
  - Parse the `sanitized` string using `urlparse`.
  - Assert that the parsed `hostname` is `"example.com"`.
This keeps test behavior aligned with the comment (“preserves hostname”) while eliminating the substring-based check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
